### PR TITLE
Add Github action workflow for testing, code coverage, and package production

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,0 +1,32 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install coveralls nose2 pylint setuptools wheel
+    - name: Test with nose2
+      run: |
+        cd tests && nose2 -C --coverage ../communityid --coverage-report term-missing communityid_test
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Preserve built package
+      uses: actions/upload-artifact@v2
+      with:
+        name: communityid-py${{ matrix.python-version }}.tar.gz
+        path: dist/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ flow hashing standard.
 
 It supports Python versions 2.7+ and 3+.
 
+![example foobar](https://github.com/corelight/pycommunityid/actions/workflows/python.yaml/badge.svg)
+
 Installation
 ------------
 
@@ -62,9 +64,9 @@ The package includes three sample applications:
 Testing
 -------
 
-The package includes a unittest testsuite in the tests directory that
-runs without installation of the module. You can invoke it as usual,
-e.g. via:
+The package includes a unittest testsuite in the `tests` directory
+that runs without installation of the module. After changing into that
+folder you can invoke it e.g. via
 
     python -m unittest communityid_test
 
@@ -72,3 +74,4 @@ or
 
     nose2 -C --coverage ../communityid --coverage-report term-missing communityid_test
 
+or by running `./communityid_test.py` directly.

--- a/scripts/community-id
+++ b/scripts/community-id
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 """
 This script lets you compute Community ID values for specific flow tuples.
 You provide the tuple parts, it provides the ID.

--- a/scripts/community-id-pcap
+++ b/scripts/community-id-pcap
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 """
 This script computes Community ID hashes for network flows in
 provided pcaps. Provide pcaps (not pcapng) to the script and it will

--- a/scripts/community-id-tcpdump
+++ b/scripts/community-id-tcpdump
@@ -1,4 +1,4 @@
-#! /bin/env python
+#! /usr/bin/env python
 """
 An example of Community ID use based on high-level, textual
 addresses / ports as input. This script parses tcpdump output on stdin


### PR DESCRIPTION
This also adds a bit of robustness for the testsuite in how it locates the provided scripts and test inputs. That way you can also invoke the (deprecated) `python setup.py test` from the toplevel, for example.

Code coverage is produced but not yet exported.