### PR TITLE
Add logging support to the package and make hash buffer build-up visible in the community-id command

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/communityid/__init__.py
+++ b/communityid/__init__.py
@@ -5,6 +5,11 @@ We pull in all the objects and variables you'd commonly need. The user
 should be fine just importing this, and not need any of the
 submodules.
 """
+import logging
+
+LOG = logging.getLogger(__name__)
+LOG.addHandler(logging.NullHandler())
+
 from communityid.error import Error, FlowTupleError
 from communityid.algo import FlowTuple
 from communityid.algo import CommunityID

--- a/communityid/algo.py
+++ b/communityid/algo.py
@@ -5,6 +5,7 @@ import abc
 import base64
 import collections
 import hashlib
+import logging
 import socket
 import string
 import struct
@@ -13,6 +14,8 @@ from communityid import error
 from communityid import compat
 from communityid import icmp
 from communityid import icmp6
+
+from . import LOG
 
 # Proper enums here would be nice, but this aims to support Python
 # 2.7+ and while there are ways to get "proper" enums pre-3.0, it just

--- a/communityid/algo.py
+++ b/communityid/algo.py
@@ -134,12 +134,14 @@ class FlowTuple:
 
     def __repr__(self):
         data = self.get_data()
+        ordered = 'ordered' if self.is_ordered() else 'flipped'
 
         if data.sport is None or data.dport is None:
-            return '[%s] %s -> %s' % (data.proto, data.saddr, data.daddr)
+            return '%s -> %s, proto %s, %s' % (
+                data.saddr, data.daddr, data.proto, ordered)
 
-        return '[%s] %s/%s -> %s/%s' % (data.proto, data.saddr, data.sport,
-                                        data.daddr, data.dport)
+        return '%s %s -> %s %s, proto %s, %s' % (
+            data.saddr, data.sport, data.daddr, data.dport, data.proto, ordered)
 
     def get_data(self):
         """

--- a/scripts/community-id
+++ b/scripts/community-id
@@ -5,6 +5,7 @@ You provide the tuple parts, it provides the ID.
 """
 import abc
 import argparse
+import logging
 import socket
 import sys
 
@@ -106,8 +107,9 @@ does not matter.
                         help='Seed value for hash operations')
     parser.add_argument('--no-base64', action='store_true', default=False,
                         help="Don't base64-encode the SHA1 binary value")
-    parser.add_argument('--verbose', action='store_true', default=False,
-                        help='Enable verbose output')
+    parser.add_argument('--verbose', '-v', action='count', default=0,
+                        help=('Enable verbose output. Use multiple times '
+                              'for more output (e.g. -vvv).'))
     parser.add_argument('flowtuple', nargs=argparse.REMAINDER,
                         help='Flow tuple, in one of the forms described above')
     args = parser.parse_args()
@@ -116,14 +118,27 @@ does not matter.
         sys.stderr.write('Need flow tuple as additional arguments.\n')
         return 1
 
+    if args.verbose > 0:
+        formatter = logging.Formatter('%(levelname)-8s %(message)s')
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+
+        if args.verbose == 1:
+            communityid.LOG.setLevel(logging.WARNING)
+        elif args.verbose == 2:
+            communityid.LOG.setLevel(logging.INFO)
+        elif args.verbose >= 3:
+            communityid.LOG.setLevel(logging.DEBUG)
+
+        communityid.LOG.addHandler(handler)
+
     commid = communityid.CommunityID(args.seed, not args.no_base64)
 
     for parser in (DefaultParser(), ZeekLogsParser()):
         tpl, msg = parser.parse(args.flowtuple)
         if tpl is None:
-            if args.verbose:
-                sys.stderr.write('%s failure: %s\n' %
-                                 (parser.__class__.__name__, msg))
+            communityid.LOG.debug(
+                '%s failure: %s\n' % (parser.__class__.__name__, msg))
             continue
 
         res = commid.calc(tpl)

--- a/tests/communityid_test.py
+++ b/tests/communityid_test.py
@@ -378,6 +378,21 @@ class TestCommands(unittest.TestCase):
             env=self.env)
         self.assertEqual(out, b'1:9j2Dzwrw7T9E+IZi4b4IVT66HBI=\n')
 
+    def test_communityid_verbose(self):
+        out = subprocess.check_output(
+            [self._scriptpath('community-id'), '-vv', 'tcp', '10.0.0.1', '10.0.0.2', '10', '20'],
+            env=self.env, stderr=subprocess.STDOUT)
+        self.assertEqual(out, b"""INFO     CommunityID for 10.0.0.1 10 -> 10.0.0.2 20, proto 6, ordered:
+INFO     | seed    00:00
+INFO     | ipaddr  0a:00:00:01
+INFO     | ipaddr  0a:00:00:02
+INFO     | proto   06
+INFO     | padding 00
+INFO     | port    00:0a
+INFO     | port    00:14
+1:9j2Dzwrw7T9E+IZi4b4IVT66HBI=
+""")
+
     def _check_output_community_id_pcap(self, args):
         try:
             args = [self._scriptpath('community-id-pcap')] + args


### PR DESCRIPTION
One can now see the input into the hash buffer when running `community-id` with at least `-vv`:

```
$ community-id -vv 2607:f8b0:400c:c03::1a 25 2001:470:e5bf:dead:4957:2174:e82c:4887 63943 6
INFO     CommunityID for 2607:f8b0:400c:c03::1a 25 -> 2001:470:e5bf:dead:4957:2174:e82c:4887 63943, proto 6, flipped:
INFO     | seed    00:00
INFO     | ipaddr  20:01:04:70:e5:bf:de:ad:49:57:21:74:e8:2c:48:87
INFO     | ipaddr  26:07:f8:b0:40:0c:0c:03:00:00:00:00:00:00:00:1a
INFO     | proto   06
INFO     | padding 00
INFO     | port    f9:c7
INFO     | port    00:19
1:/qFaeAR+gFe1KYjMzVDsMv+wgU4=
```